### PR TITLE
Fixed broken build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,7 @@
 		</dependency>
 		<dependency>
 			<groupId>org.jogamp.jogl</groupId>
-			<artifactId>jogl-all</artifactId>
+			<artifactId>jogl-all-main</artifactId>
 			<version>2.4.0-rc-20230123</version>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,14 @@
 	</properties>
 	<build>
 		<sourceDirectory>processing4\core\src</sourceDirectory>
+		<resources>
+			<resource>
+				<directory>processing4\core\src</directory>
+				<excludes>
+					<exclude>**/*.java</exclude>
+				</excludes>
+			</resource>
+		</resources>
 		<plugins>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -15,10 +15,7 @@
 		<sourceDirectory>processing4\core\src</sourceDirectory>
 		<resources>
 			<resource>
-				<directory>processing4\core\src</directory>
-				<excludes>
-					<exclude>**/*.java</exclude>
-				</excludes>
+				<directory>processing4/core/src/processing/opengl/shaders/</directory>
 			</resource>
 		</resources>
 		<plugins>


### PR DESCRIPTION
This build wasn't working for me for two reasons:

Missing native library files. You need to use jogl-all-main to get all the dependencies. [See here](https://jogamp.org/wiki/index.php/Maven)

Missing shader files from processing4\core\src\opengl\shaders because the resources directory was removed from POM. 
