### PR TITLE
Preserve folder structure for resources

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,11 @@
 		<testSourceDirectory>processing4\core\test\</testSourceDirectory>
 		<resources>
 			<resource>
-				<directory>processing4/core/src/processing/opengl/shaders/</directory>
+				<directory>processing4\core\src</directory>
+				<includes>
+				  	<include>**\processing\opengl\shaders\</include>
+					<include>**\processing\opengl\cursors\</include>
+				</includes>
 			</resource>
 		</resources>
 		<plugins>


### PR DESCRIPTION
Messed up my previous pom edit.. It put all the resource files in the root instead of subdir where Processing looks for them. Also included the cursors folder.